### PR TITLE
fix bug because of order of operations

### DIFF
--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -24,7 +24,7 @@ class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry) (implic
 
     nextFilter(requestHeader).map { result =>
       val endTime = System.nanoTime
-      val requestTime = endTime - startTime / Collector.NANOSECONDS_PER_SECOND
+      val requestTime = (endTime - startTime) / Collector.NANOSECONDS_PER_SECOND
       val routeLabel = requestHeader.attrs
         .get(Router.Attrs.HandlerDef)
         .map(_.method)


### PR DESCRIPTION
I was noticing all my request were in the `+Inf` bucket and the `sum` seemed way too high. I believe this fixes an order of operations bug

```
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.005",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.01",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.025",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.05",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.075",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.1",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.25",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.5",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="0.75",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="1.0",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="2.5",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="5.0",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="7.5",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="10.0",} 0.0
requests_latency_seconds_bucket{RouteActionMethod="notifications",Status="200",le="+Inf",} 26.0
requests_latency_seconds_count{RouteActionMethod="notifications",Status="200",} 26.0
requests_latency_seconds_sum{RouteActionMethod="notifications",Status="200",} 1.2272531440506882E16
```