### PR TITLE
Feature/configurable filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,57 @@ And the enable this filter in the application.conf
 play.http.filters=com.example.MyFilters
 ```
 
+## Customizing metrics or building your own filters
+
+The setup of a filter is very simple: extend the `MetricFilter` class and define a `metrics` property with a list of metrics
+you want your filter to use.
+
+E.g. the `LatencyFilter` looks like this:
+```scala
+@Singleton
+class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
+
+  override val metrics = List(
+    LatencyOnlyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+  )
+}
+``` 
+
+The `@Singleton` annotation ensures the application creates only a single instance of it.
+Via the `@Inject` annotation, Play will automatically pass available instances into the contructor (using [Guice DI](https://github.com/google/guice/wiki/Motivation)).
+The `CollectorRegistry` is needed to register a metric. The `Configuration` may contain information about paths to exclude for metrics.
+This is handled by the `MetricsFilter` class.
+
+You can customize a filter in different ways
+
+- Define one or more metrics in the `metrics` list (other than in the filters already provided).
+See `CounterRequestMetrics` and `LatencyRequestMetrics` for provided metric types.
+
+- You can define you own metric. E.g. currently only `Counter` and `Histogram` (Latency) metrics are provided.
+If you'd like to use Prometheus's `Summary` or `Gauge` metric, you can implement your own metric by creating
+a `RequestMetric` implementation and a corresponding `RequestMetricBuilder`.  
+See `CounterRequestMetrics` and `LatencyRequestMetrics` for how to implement your own builder and metric.  
+The builder, `builds` sets up the metrics instance with a name, help, labels, etc and registers the metric.
+Then it returns a `RequestMetric` instance which uses the metric. Implement the `mark` function to pass labels 
+to the metric using data from either the request or response, then call the 'metric'-function like `observe` or `inc`
+to apply the metrics.
+
+- Customize the handling of defaults in case a certain label cannot be found.
+This can be done by providing a custom `UnmachedDefaults` implementation. The default implementation
+always returns a fixed string like `unmatchedPath` if the `path` property cannot be determined.
+
+  E.g. a custom implementation could use the 'uri' property from the request, which is always available, instead of just a fixed string.
+Using this on a Counter metric would give you insight into which non-existing urls are being used. A country creates a single metric bucket per unique uri.   
+_You probably would not want to use dynamic default properties on a Latency or Summary metric since that would give many metric buckets per unique url`_
+
+  ```scala
+  case object DynamicUnmatchedDefaults extends UnmatchedDefaults {
+    val unmatchedPath: RequestHeader => String = _.uri
+  }
+  ```
+ 
+
+
 ## Prometheus controller
 The project also provides a prometheus controller with a get metric method. If you add the following to your routes file:
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,18 @@ _You probably would not want to use dynamic default properties on a Latency or S
   }
   ```
  
+## Excluding paths from metrics
+A path can be excluded from metrics by adding it to the `play-prometheus-filters.exclude.paths` property in the `application.conf`.
+E.g. when using the `PrometheusController` you might want to exclude the path on which you configured the controller in the `routes` file.
 
+By default, the `/metrics` is excluded.
+
+```
+play-prometheus-filters {
+  # exclude /metrics endpoint assuming PrometheusController is routed to this uri
+  exclude.paths = ["/metrics"]
+}
+```
 
 ## Prometheus controller
 The project also provides a prometheus controller with a get metric method. If you add the following to your routes file:

--- a/app/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusController.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusController.scala
@@ -9,6 +9,16 @@ import io.prometheus.client.exporter.common.TextFormat
 import org.slf4j.LoggerFactory
 import play.api.http.HttpEntity
 
+/**
+  * A Play controller implementation to return collected metrics.
+  * Use this controller to create an endpoint which can be scraped by Prometheus.
+  *
+  * Add to your `routes.conf`:
+  * {{{
+  *   # Prometheus metrics
+  *   GET  /metrics  com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController.getMetrics
+  * }}}
+  */
 class PrometheusController @Inject()(registry: CollectorRegistry, cc: ControllerComponents) extends AbstractController(cc) {
 
   private val logger = LoggerFactory.getLogger(classOf[PrometheusController])

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
@@ -3,13 +3,14 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyOnlyRequestMetricsBuilder
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class LatencyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     LatencyOnlyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
@@ -1,10 +1,10 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyOnlyRequestMetricsBuilder
-import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -16,6 +16,6 @@ import scala.concurrent.ExecutionContext
 class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    LatencyOnlyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+    LatencyOnlyRequestMetricsBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
@@ -9,6 +9,9 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A simple [[MetricsFilter]] using a histogram metric to record latency without any labels.
+  */
 @Singleton
 class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 abstract class MetricsFilter(configuration: Configuration)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
 
-  val metrics: List[RequestMetric[_]]
+  val metrics: List[RequestMetric[_, RequestHeader, Result]]
 
   val excludePaths = {
     import collection.JavaConverters._

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Generic filter implementation to add metrics for a request.
   * Subclasses only have to define the `metrics` property to apply metrics.
   *
-  * ```
+  * {{{
   * @Singleton
   * class MyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
   *
@@ -19,13 +19,13 @@ import scala.concurrent.{ExecutionContext, Future}
   *     LatencyOnlyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
   *   )
   * }
-  * ```
+  * }}}
   *
-  * Metrics can be created by using a [[com.github.stijndehaes.playprometheusfilters.metrics.RequestMetricBuilder]].
+  * Metrics can be created by using a [[com.github.stijndehaes.playprometheusfilters.metrics.RequestMetricBuilder RequestMetricBuilder]].
   * The builder creates and configures the metrics for the class instance.
   *
-  * See [[com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics]] and
-  * [[com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics]] for some provided
+  * See [[com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics CounterRequestMetrics]] and
+  * [[com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics LatencyRequestMetrics]] for some provided
   * builders.
   *
   * @param mat

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
@@ -1,0 +1,52 @@
+package com.github.stijndehaes.playprometheusfilters.filters
+import akka.stream.Materializer
+import com.github.stijndehaes.playprometheusfilters.metrics.RequestMetric
+import io.prometheus.client.Collector
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Generic filter implementation to add metrics for a request.
+  * Subclasses only have to define the `metrics` property to apply metrics.
+  *
+  * ```
+  * @Singleton
+  * class MyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+  *
+  *   override val metrics = List(
+  *     LatencyOnlyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+  *   )
+  * }
+  * ```
+  *
+  * Metrics can be created by using a [[com.github.stijndehaes.playprometheusfilters.metrics.RequestMetricBuilder]].
+  * The builder creates and configures the metrics for the class instance.
+  *
+  * See [[com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics]] and
+  * [[com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics]] for some provided
+  * builders.
+  *
+  * @param mat
+  * @param ec
+  */
+abstract class MetricsFilter(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+
+  val metrics: List[RequestMetric[_]]
+
+  def apply(nextFilter: RequestHeader => Future[Result])
+           (requestHeader: RequestHeader): Future[Result] = {
+
+    val startTime = System.nanoTime
+
+    nextFilter(requestHeader).map { implicit result =>
+      implicit val rh = requestHeader
+      val endTime = System.nanoTime
+      val requestTime = (endTime - startTime) / Collector.NANOSECONDS_PER_SECOND
+
+      metrics.foreach(_.mark(requestTime))
+
+      result
+    }
+  }
+}

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
@@ -1,37 +1,17 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.RouteLatencyRequestMetricsBuilder
 import com.google.inject.{Inject, Singleton}
-import io.prometheus.client.{CollectorRegistry, Histogram}
-import play.api.mvc.{Filter, RequestHeader, Result}
-import play.api.routing.Router
+import io.prometheus.client.CollectorRegistry
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class RouteLatencyFilter @Inject()(registry: CollectorRegistry) (implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class RouteLatencyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
 
-  private[filters] val requestLatency = Histogram.build
-    .name("requests_latency_seconds")
-    .help("Request latency in seconds.")
-    .labelNames("RouteActionMethod")
-    .register(registry)
-
-  def apply(nextFilter: RequestHeader => Future[Result])
-    (requestHeader: RequestHeader): Future[Result] = {
-    val routeLabel = requestHeader.attrs
-      .get(Router.Attrs.HandlerDef)
-      .map(_.method)
-      .getOrElse(RouteLatencyFilter.unmatchedRoute)
-    val requestTimer = requestLatency.labels(routeLabel).startTimer
-    nextFilter(requestHeader).map { result =>
-      requestTimer.observeDuration()
-      result
-    }
-  }
-
-}
-
-object RouteLatencyFilter {
-  val unmatchedRoute: String = "unmatchedRoute"
+  override val metrics = List(
+    RouteLatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+  )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
@@ -3,13 +3,14 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.RouteLatencyRequestMetricsBuilder
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class RouteLatencyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class RouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     RouteLatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
@@ -1,10 +1,10 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.RouteLatencyRequestMetricsBuilder
-import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -17,6 +17,6 @@ import scala.concurrent.ExecutionContext
 class RouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    RouteLatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+    RouteLatencyRequestMetricsBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
@@ -9,6 +9,10 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A simple [[MetricsFilter]] using a counter metric to count requests.
+  * Only adds a 'route' label.
+  */
 @Singleton
 class RouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
@@ -2,9 +2,9 @@ package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
-import javax.inject.{ Inject, Singleton }
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import io.prometheus.client.CollectorRegistry
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -17,6 +17,6 @@ import scala.concurrent.ExecutionContext
 class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    CounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)
+    CounterRequestMetricBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
@@ -9,6 +9,10 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A [[MetricsFilter]] using a counter metric to count requests.
+  * Adds a 'method', 'status', 'controller', 'path' and 'verb' labels.
+  */
 @Singleton
 class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
@@ -1,56 +1,17 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
+import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.google.inject.{Inject, Singleton}
-import io.prometheus.client.{CollectorRegistry, Counter}
-import play.api.mvc.{Filter, RequestHeader, Result}
-import play.api.routing.Router
+import io.prometheus.client.CollectorRegistry
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
 
-  private[filters] val requestCounter = Counter.build()
-    .name("http_requests_total")
-    .help("Total amount of requests")
-    .labelNames("method", "status", "controller", "path", "verb")
-    .register(registry)
-
-  def apply(nextFilter: RequestHeader => Future[Result])
-    (requestHeader: RequestHeader): Future[Result] = {
-
-    nextFilter(requestHeader).map { result =>
-      val methodLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.method)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedRoute)
-      val statusLabel = result.header.status.toString
-      val controllerLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.controller)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedController)
-      val pathLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.path)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedPath)
-      val verbLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.verb)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedVerb)
-      requestCounter.labels(methodLabel, statusLabel, controllerLabel, pathLabel, verbLabel).inc()
-      result
-    }
-  }
-
+  override val metrics = List(
+    CounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)
+  )
 }
-
-object StatusAndRouteCounterFilter {
-  val unmatchedRoute: String = "unmatchedRoute"
-  val unmatchedController: String = "unmatchedController"
-  val unmatchedPath: String = "unmatchedPath"
-  val unmatchedVerb: String = "unmatchedVerb"
-}
-
-
-

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
@@ -3,13 +3,14 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class StatusAndRouteCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     CounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
@@ -2,10 +2,10 @@ package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import javax.inject.{ Inject, Singleton }
 import io.prometheus.client._
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -20,7 +20,7 @@ import scala.concurrent.ExecutionContext
 class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults),
-    CounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)
+    LatencyRequestMetricsBuilder.build(registry, DefaultPlayUnmatchedDefaults),
+    CounterRequestMetricBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
@@ -10,6 +10,12 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A [[MetricsFilter]] using a both a histogram and counter metric to record latency and count requests.
+  *
+  * Latency metric adds 'RouteActionMethod', 'Status', 'Controller', 'Path' and 'Verb' labels.  
+  * Counter metric adds 'method', 'status', 'controller', 'path' and 'verb' labels.
+  */
 @Singleton
 class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
@@ -4,13 +4,14 @@ import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import io.prometheus.client._
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults),

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
@@ -1,70 +1,19 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
+import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
 import com.google.inject.{Inject, Singleton}
-import io.prometheus.client.{Collector, CollectorRegistry, Counter, Histogram}
-import play.api.mvc.{Filter, RequestHeader, Result}
-import play.api.routing.Router
+import io.prometheus.client._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class StatusAndRouteLatencyAndCounterFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
 
-  private[filters] val requestCounter = Counter.build()
-    .name("http_requests_total")
-    .help("Total amount of requests")
-    .labelNames("method", "status", "controller", "path", "verb")
-    .register(registry)
-
-  private[filters] val requestLatency = Histogram.build
-    .name("requests_latency_seconds")
-    .help("Request latency in seconds.")
-    .labelNames("RouteActionMethod", "Status", "Controller", "Path", "Verb")
-    .register(registry)
-
-  def apply(nextFilter: RequestHeader => Future[Result])
-    (requestHeader: RequestHeader): Future[Result] = {
-
-    val startTime = System.nanoTime
-
-    nextFilter(requestHeader).map { result =>
-      val endTime = System.nanoTime
-      val requestTime = (endTime - startTime) / Collector.NANOSECONDS_PER_SECOND
-      val methodLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.method)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedRoute)
-      val statusLabel = result.header.status.toString
-      val controllerLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.controller)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedController)
-      val pathLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.path)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedPath)
-      val verbLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.verb)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedVerb)
-      requestLatency.labels(methodLabel, statusLabel, controllerLabel, pathLabel, verbLabel).observe(requestTime)
-      requestCounter.labels(methodLabel, statusLabel, controllerLabel, pathLabel, verbLabel).inc()
-      result
-    }
-  }
-
+  override val metrics = List(
+    LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults),
+    CounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)
+  )
 }
-
-object StatusAndRouteLatencyAndCounterFilter {
-  val unmatchedRoute: String = "unmatchedRoute"
-  val unmatchedController: String = "unmatchedController"
-  val unmatchedPath: String = "unmatchedPath"
-  val unmatchedVerb: String = "unmatchedVerb"
-}
-
-
-
-
-
-

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -3,13 +3,14 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -9,6 +9,10 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A [[MetricsFilter]] using a histogram metric to record latency.
+  * Latency metric adds 'RouteActionMethod', 'Status', 'Controller', 'Path' and 'Verb' labels.
+  */
 @Singleton
 class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -1,10 +1,10 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import javax.inject.{ Inject, Singleton }
 import io.prometheus.client.CollectorRegistry
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -17,6 +17,6 @@ import scala.concurrent.ExecutionContext
 class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+    LatencyRequestMetricsBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -1,60 +1,17 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
 import com.google.inject.{Inject, Singleton}
-import io.prometheus.client.{Collector, CollectorRegistry, Histogram}
-import play.api.mvc.{Filter, RequestHeader, Result}
-import play.api.routing.Router
+import io.prometheus.client.CollectorRegistry
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class StatusAndRouteLatencyFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
 
-  private[filters] val requestLatency = Histogram.build
-    .name("requests_latency_seconds")
-    .help("Request latency in seconds.")
-    .labelNames("RouteActionMethod", "Status", "Controller", "Path", "Verb")
-    .register(registry)
-
-  def apply(nextFilter: RequestHeader => Future[Result])
-    (requestHeader: RequestHeader): Future[Result] = {
-
-    val startTime = System.nanoTime
-
-    nextFilter(requestHeader).map { result =>
-      val endTime = System.nanoTime
-      val requestTime = (endTime - startTime) / Collector.NANOSECONDS_PER_SECOND
-      val routeLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.method)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedRoute)
-      val statusLabel = result.header.status.toString
-      val controllerLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.controller)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedController)
-      val pathLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.path)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedPath)
-      val verbLabel = requestHeader.attrs
-        .get(Router.Attrs.HandlerDef)
-        .map(_.verb)
-        .getOrElse(StatusAndRouteLatencyFilter.unmatchedVerb)
-      requestLatency.labels(routeLabel, statusLabel, controllerLabel, pathLabel, verbLabel).observe(requestTime)
-      result
-    }
-  }
-
+  override val metrics = List(
+    LatencyRequestMetricsBuilder.build(registry, DefaultUnmatchedDefaults)
+  )
 }
-
-object StatusAndRouteLatencyFilter {
-  val unmatchedRoute: String = "unmatchedRoute"
-  val unmatchedController: String = "unmatchedController"
-  val unmatchedPath: String = "unmatchedPath"
-  val unmatchedVerb: String = "unmatchedVerb"
-}
-
-
-

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
@@ -3,14 +3,14 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.StatusCounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
-import com.google.inject.Singleton
 import io.prometheus.client.CollectorRegistry
-import javax.inject.Inject
+import javax.inject.{ Inject, Singleton }
+import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class StatusCounterFilter @Inject()(registry: CollectorRegistry)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter {
+class StatusCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
     StatusCounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
@@ -2,9 +2,9 @@ package com.github.stijndehaes.playprometheusfilters.filters
 
 import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.StatusCounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{ Inject, Singleton }
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -17,6 +17,6 @@ import scala.concurrent.ExecutionContext
 class StatusCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
   override val metrics = List(
-    StatusCounterRequestMetricBuilder.build(registry, DefaultUnmatchedDefaults)
+    StatusCounterRequestMetricBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
@@ -9,6 +9,10 @@ import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * A [[MetricsFilter]] using a counter metric to count requests statuses.
+  * Only adds a 'status' label containing the status codes.
+  */
 @Singleton
 class StatusCounterFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
@@ -64,8 +64,8 @@ trait RequestMetricBuilder[RM <: RequestMetric[_]] {
 /**
   * Provides some builders counter request metrics.
   *
-  * - StatusCounterRequestMetricBuilder: count with response status code label
-  * - CounterRequestMetricBuilder: count requests with labels method, status, controller, path and verb
+  *  - StatusCounterRequestMetricBuilder: count with response status code label
+  *  - CounterRequestMetricBuilder: count requests with labels method, status, controller, path and verb
   */
 object CounterRequestMetrics {
 
@@ -110,9 +110,9 @@ object CounterRequestMetrics {
 /**
   * Provides some builders latency request metrics.
   *
-  * - LatencyRequestMetricsBuilder: observe latency with route, status, controller, path and verb labels.
-  * - LatencyOnlyRequestMetricsBuilder: only observe latency. No labels.
-  * - RouteLatencyRequestMetricsBuilder: observe latency with only route label.
+  *  - LatencyRequestMetricsBuilder: observe latency with route, status, controller, path and verb labels.
+  *  - LatencyOnlyRequestMetricsBuilder: only observe latency. No labels.
+  *  - RouteLatencyRequestMetricsBuilder: observe latency with only route label.
   */
 object LatencyRequestMetrics {
   /**

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
@@ -1,0 +1,172 @@
+package com.github.stijndehaes.playprometheusfilters.metrics
+import io.prometheus.client.{CollectorRegistry, Counter, Histogram, SimpleCollector}
+import play.api.mvc.{RequestHeader, Result}
+import play.api.routing.Router
+
+/**
+  * Generic request metric.
+  * Provides convenience methods for getting labels from the request or response.
+  *
+  * @tparam M Type of metric. E.g. Counter or Histogram.
+  */
+trait RequestMetric[M <: SimpleCollector[_]] {
+  val metric: M
+  val unmatchedDefaults: UnmatchedDefaults
+
+  def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit
+
+  def pathLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
+    .get(Router.Attrs.HandlerDef)
+    .map(_.path)
+    .getOrElse(unmatchedDefaults.unmatchedPath(requestHeader))
+
+  def methodLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
+    .get(Router.Attrs.HandlerDef)
+    .map(_.method)
+    .getOrElse(unmatchedDefaults.unmatchedRoute(requestHeader))
+
+  def statusLabel(implicit result: Result) = result.header.status.toString
+
+  def controllerLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
+    .get(Router.Attrs.HandlerDef)
+    .map(_.controller)
+    .getOrElse(unmatchedDefaults.unmatchedController(requestHeader))
+
+  def verbLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
+    .get(Router.Attrs.HandlerDef)
+    .map(_.verb)
+    .getOrElse(unmatchedDefaults.unmatchedVerb(requestHeader))
+
+  def routeLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
+    .get(Router.Attrs.HandlerDef)
+    .map(_.method)
+    .getOrElse(unmatchedDefaults.unmatchedRoute(requestHeader))
+}
+
+/**
+  * Counter metric implementation.
+  */
+abstract class CounterRequestMetric(val metric: Counter, val unmatchedDefaults: UnmatchedDefaults) extends RequestMetric[Counter]
+
+/**
+  * Latency metric implementation using a histogram.
+  */
+abstract class LatencyRequestMetric(val metric: Histogram, val unmatchedDefaults: UnmatchedDefaults) extends RequestMetric[Histogram]
+
+/**
+  * A generic request metric builder.
+  * @tparam RM Type of request metric.
+  */
+trait RequestMetricBuilder[RM <: RequestMetric[_]] {
+  def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): RM
+}
+
+/**
+  * Provides some builders counter request metrics.
+  *
+  * - StatusCounterRequestMetricBuilder: count with response status code label
+  * - CounterRequestMetricBuilder: count requests with labels method, status, controller, path and verb
+  */
+object CounterRequestMetrics {
+
+  /**
+    * Count requests with status label
+    */
+  object StatusCounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): CounterRequestMetric = {
+      val counter = Counter.build()
+        .name("http_requests_total")
+        .help("Total amount of requests")
+        .labelNames("status")
+        .register(registry)
+      return new CounterRequestMetric(counter, unmatchedDefaults) {
+        override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
+          counter.labels(statusLabel).inc()
+        }
+      }
+    }
+  }
+
+
+  /**
+    * Count requests with labels method, status, controller, path and verb
+    */
+  object CounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): CounterRequestMetric = {
+      val counter = Counter.build()
+        .name("http_requests_total")
+        .help("Total amount of requests")
+        .labelNames("method", "status", "controller", "path", "verb")
+        .register(registry)
+      return new CounterRequestMetric(counter, unmatchedDefaults) {
+        override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
+          counter.labels(methodLabel, statusLabel, controllerLabel, pathLabel, verbLabel).inc()
+        }
+      }
+    }
+  }
+}
+
+/**
+  * Provides some builders latency request metrics.
+  *
+  * - LatencyRequestMetricsBuilder: observe latency with route, status, controller, path and verb labels.
+  * - LatencyOnlyRequestMetricsBuilder: only observe latency. No labels.
+  * - RouteLatencyRequestMetricsBuilder: observe latency with only route label.
+  */
+object LatencyRequestMetrics {
+  /**
+    * Observe latency with route, status, controller, path and verb labels.
+    */
+  object LatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+      val metric = Histogram.build
+        .name("requests_latency_seconds")
+        .help("Request latency in seconds.")
+        .labelNames("RouteActionMethod", "Status", "Controller", "Path", "Verb")
+        .register(registry)
+
+      new LatencyRequestMetric(metric, unmatchedDefaults) {
+        override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
+          metric.labels(routeLabel, statusLabel, controllerLabel, pathLabel, verbLabel).observe(requestTime)
+        }
+      }
+    }
+  }
+
+  /**
+    * Only observe latency. No labels.
+    */
+  object LatencyOnlyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+      val metric = Histogram.build
+        .name("requests_latency_seconds")
+        .help("Request latency in seconds.")
+        .register(registry)
+      new LatencyRequestMetric(metric, unmatchedDefaults) {
+        override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
+          metric.observe(requestTime)
+        }
+      }
+    }
+  }
+
+  /**
+    * Observe latency with only route label.
+    */
+  object RouteLatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+      val metric = Histogram.build
+        .name("requests_latency_seconds")
+        .help("Request latency in seconds.")
+        .labelNames("RouteActionMethod")
+        .register(registry)
+
+      new LatencyRequestMetric(metric, unmatchedDefaults) {
+        override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
+          metric.labels(routeLabel).observe(requestTime)
+        }
+      }
+    }
+  }
+}

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
@@ -18,6 +18,7 @@ trait RequestMetric[M <: SimpleCollector[_]] {
   def pathLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs
     .get(Router.Attrs.HandlerDef)
     .map(_.path)
+    .map(_.replaceAll("<\\[\\^/]\\+>", "")) // remove dynamic part from argument so it's more readable
     .getOrElse(unmatchedDefaults.unmatchedPath(requestHeader))
 
   def methodLabel(implicit requestHeader: RequestHeader): String = requestHeader.attrs

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
@@ -11,7 +11,7 @@ import play.api.routing.Router
   */
 trait RequestMetric[M <: SimpleCollector[_]] {
   val metric: M
-  val unmatchedDefaults: UnmatchedDefaults
+  val unmatchedDefaults: UnmatchedDefaults[RequestHeader]
 
   def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit
 
@@ -47,19 +47,19 @@ trait RequestMetric[M <: SimpleCollector[_]] {
 /**
   * Counter metric implementation.
   */
-abstract class CounterRequestMetric(val metric: Counter, val unmatchedDefaults: UnmatchedDefaults) extends RequestMetric[Counter]
+abstract class CounterRequestMetric(val metric: Counter, val unmatchedDefaults: UnmatchedDefaults[RequestHeader]) extends RequestMetric[Counter]
 
 /**
   * Latency metric implementation using a histogram.
   */
-abstract class LatencyRequestMetric(val metric: Histogram, val unmatchedDefaults: UnmatchedDefaults) extends RequestMetric[Histogram]
+abstract class LatencyRequestMetric(val metric: Histogram, val unmatchedDefaults: UnmatchedDefaults[RequestHeader]) extends RequestMetric[Histogram]
 
 /**
   * A generic request metric builder.
   * @tparam RM Type of request metric.
   */
-trait RequestMetricBuilder[RM <: RequestMetric[_]] {
-  def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): RM
+trait RequestMetricBuilder[RM <: RequestMetric[_], T] {
+  def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[T]): RM
 }
 
 /**
@@ -73,8 +73,8 @@ object CounterRequestMetrics {
   /**
     * Count requests with status label
     */
-  object StatusCounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric] {
-    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): CounterRequestMetric = {
+  object StatusCounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric, RequestHeader] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[RequestHeader]): CounterRequestMetric = {
       val counter = Counter.build()
         .name("http_requests_total")
         .help("Total amount of requests")
@@ -92,8 +92,8 @@ object CounterRequestMetrics {
   /**
     * Count requests with labels method, status, controller, path and verb
     */
-  object CounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric] {
-    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults): CounterRequestMetric = {
+  object CounterRequestMetricBuilder extends RequestMetricBuilder[CounterRequestMetric, RequestHeader] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[RequestHeader]): CounterRequestMetric = {
       val counter = Counter.build()
         .name("http_requests_total")
         .help("Total amount of requests")
@@ -119,8 +119,8 @@ object LatencyRequestMetrics {
   /**
     * Observe latency with route, status, controller, path and verb labels.
     */
-  object LatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
-    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+  object LatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric, RequestHeader] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[RequestHeader]) = {
       val metric = Histogram.build
         .name("requests_latency_seconds")
         .help("Request latency in seconds.")
@@ -138,8 +138,8 @@ object LatencyRequestMetrics {
   /**
     * Only observe latency. No labels.
     */
-  object LatencyOnlyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
-    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+  object LatencyOnlyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric, RequestHeader] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[RequestHeader]) = {
       val metric = Histogram.build
         .name("requests_latency_seconds")
         .help("Request latency in seconds.")
@@ -155,8 +155,8 @@ object LatencyRequestMetrics {
   /**
     * Observe latency with only route label.
     */
-  object RouteLatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric] {
-    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults) = {
+  object RouteLatencyRequestMetricsBuilder extends RequestMetricBuilder[LatencyRequestMetric, RequestHeader] {
+    override def build(registry: CollectorRegistry, unmatchedDefaults: UnmatchedDefaults[RequestHeader]) = {
       val metric = Histogram.build
         .name("requests_latency_seconds")
         .help("Request latency in seconds.")

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
@@ -7,12 +7,13 @@ import play.api.mvc.RequestHeader
   * This allows for customization per metric what to return in case a value does not exist.
   *
   * E.g. instead of returning a 'unmatchedVerbe' string, could get the actual verbe from the [[RequestHeader]].
-  * ```
+  *
+  * {{{
   * case object MyDefaults extends UnmatchedDefaults {
   *   // return actual http method from request
   *   override  val unmatchedVerb: RequestHeader => String = rh => rh.method
   * }
-  * ```
+  * }}}
   */
 trait UnmatchedDefaults {
 

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
@@ -1,12 +1,10 @@
 package com.github.stijndehaes.playprometheusfilters.metrics
 
-import play.api.mvc.RequestHeader
-
 /**
   * Defines default value what to return in case a certain property cannot be retrieved.
   * This allows for customization per metric what to return in case a value does not exist.
   *
-  * E.g. instead of returning a 'unmatchedVerbe' string, could get the actual verbe from the [[RequestHeader]].
+  * E.g. instead of returning a 'unmatchedVerbe' string, could get the actual verbe from a [[play.api.mvc.RequestHeader]].
   *
   * {{{
   * case object MyDefaults extends UnmatchedDefaults {
@@ -14,21 +12,23 @@ import play.api.mvc.RequestHeader
   *   override  val unmatchedVerb: RequestHeader => String = rh => rh.method
   * }
   * }}}
+  *
+  * @tparam T Request object type for web framework. E.g. for play it's the [[play.api.mvc.RequestHeader]].
   */
-trait UnmatchedDefaults {
+trait UnmatchedDefaults[T] {
 
   val UnmatchedRouteString      = "unmatchedRoute"
   val UnmatchedControllerString = "unmatchedController"
   val UnmatchedPathString       = "unmatchedPath"
   val UnmatchedVerbString       = "unmatchedVerb"
 
-  val unmatchedRoute: RequestHeader => String      = _ => UnmatchedRouteString
-  val unmatchedController: RequestHeader => String = _ => UnmatchedControllerString
-  val unmatchedPath: RequestHeader => String       = _ => UnmatchedPathString
-  val unmatchedVerb: RequestHeader => String       = _ => UnmatchedVerbString
+  val unmatchedRoute: T => String      = _ => UnmatchedRouteString
+  val unmatchedController: T => String = _ => UnmatchedControllerString
+  val unmatchedPath: T => String       = _ => UnmatchedPathString
+  val unmatchedVerb: T => String       = _ => UnmatchedVerbString
 }
 
 /**
   * Default implementation of [[UnmatchedDefaults]] which returns a fixed strings.
   */
-case object DefaultUnmatchedDefaults extends UnmatchedDefaults
+case object DefaultPlayUnmatchedDefaults extends UnmatchedDefaults[play.api.mvc.RequestHeader]

--- a/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
+++ b/app/com/github/stijndehaes/playprometheusfilters/metrics/UnmatchedDefaults.scala
@@ -1,0 +1,33 @@
+package com.github.stijndehaes.playprometheusfilters.metrics
+
+import play.api.mvc.RequestHeader
+
+/**
+  * Defines default value what to return in case a certain property cannot be retrieved.
+  * This allows for customization per metric what to return in case a value does not exist.
+  *
+  * E.g. instead of returning a 'unmatchedVerbe' string, could get the actual verbe from the [[RequestHeader]].
+  * ```
+  * case object MyDefaults extends UnmatchedDefaults {
+  *   // return actual http method from request
+  *   override  val unmatchedVerb: RequestHeader => String = rh => rh.method
+  * }
+  * ```
+  */
+trait UnmatchedDefaults {
+
+  val UnmatchedRouteString      = "unmatchedRoute"
+  val UnmatchedControllerString = "unmatchedController"
+  val UnmatchedPathString       = "unmatchedPath"
+  val UnmatchedVerbString       = "unmatchedVerb"
+
+  val unmatchedRoute: RequestHeader => String      = _ => UnmatchedRouteString
+  val unmatchedController: RequestHeader => String = _ => UnmatchedControllerString
+  val unmatchedPath: RequestHeader => String       = _ => UnmatchedPathString
+  val unmatchedVerb: RequestHeader => String       = _ => UnmatchedVerbString
+}
+
+/**
+  * Default implementation of [[UnmatchedDefaults]] which returns a fixed strings.
+  */
+case object DefaultUnmatchedDefaults extends UnmatchedDefaults

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,13 @@ organization := "com.github.stijndehaes"
 version := "0.4.0"
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala)
   .settings(
+    // sources to Play structure. No need for it, so restructure when possible.
+    scalaSource in Compile := baseDirectory.value / "app",
+    scalaSource in Test := baseDirectory.value / "test",
+    resourceDirectory in Compile := baseDirectory.value / "conf",
+    resourceDirectory in Test := baseDirectory.value / "test" / "resources",
+  
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
       if (version.value.trim.endsWith("SNAPSHOT"))
@@ -42,10 +47,13 @@ scalaVersion := "2.12.6"
 crossScalaVersions := Seq(scalaVersion.value, "2.11.12")
 
 libraryDependencies ++= Seq(
-  guice,
   "io.prometheus"             % "simpleclient"          % "0.5.0",
   "io.prometheus"             % "simpleclient_hotspot"  % "0.5.0",
-  "io.prometheus"             % "simpleclient_servlet"  % "0.5.0"
+  "io.prometheus"             % "simpleclient_servlet"  % "0.5.0",
+
+  // Play libs. Are provided not to enforce a specific version.
+  "com.typesafe.play"         %% "play"                 % "2.6.18" % Provided,
+  "com.typesafe.play"         %% "play-guice"           % "2.6.18" % Provided
 )
 
 libraryDependencies ++= Seq(

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -1,4 +1,9 @@
 play.modules.enabled += com.github.stijndehaes.playprometheusfilters.PrometheusModule
 
-# Registers some default collectors for jvm metrics. See DefaultExports class.
-play-prometheus-filters.register-default-hotspot-collectors = false
+play-prometheus-filters {
+  # Registers some default collectors for jvm metrics. See DefaultExports class.
+  register-default-hotspot-collectors = false
+
+  # exclude /metrics endpoint assuming PrometheusController is routed to this uri
+  exclude.paths = ["/metrics"]
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-// The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
@@ -33,7 +33,7 @@ class LatencyFilterSpec extends PlaySpec with MockitoSugar with Results with Def
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestLatency.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
@@ -15,11 +16,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class LatencyFilterSpec extends PlaySpec with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
+  val configuration = mock[Configuration]
+
   "Filter constructor" should {
     "Add a histogram to the prometheus registry" in {
       implicit val mat = app.materializer
       val collectorRegistry = mock[CollectorRegistry]
-      new LatencyFilter(collectorRegistry)
+      new LatencyFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
     }
   }
@@ -27,7 +30,7 @@ class LatencyFilterSpec extends PlaySpec with MockitoSugar with Results with Def
   "Apply method" should {
     "Measure the latency" in {
       implicit val mat = app.materializer
-      val filter = new LatencyFilter(mock[CollectorRegistry])
+      val filter = new LatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).ok
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
@@ -1,7 +1,7 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultUnmatchedDefaults, RequestMetric}
+import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultPlayUnmatchedDefaults, RequestMetric}
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import com.typesafe.config.ConfigFactory
 import io.prometheus.client.CollectorRegistry
@@ -38,7 +38,7 @@ class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with Defa
       val collectorRegistry = mock[CollectorRegistry]
       val filter = new MetricsFilter(configuration) {
         override val metrics = List(
-          CounterRequestMetricBuilder.build(collectorRegistry, DefaultUnmatchedDefaults)
+          CounterRequestMetricBuilder.build(collectorRegistry, DefaultPlayUnmatchedDefaults)
         )
       }
 
@@ -53,5 +53,4 @@ class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with Defa
       samples.size() mustBe 0 // expect no metrics
     }
   }
-
 }

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
@@ -25,7 +25,7 @@ class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with Defa
     "Get exclude paths from configuration" in {
       implicit val mat = app.materializer
       val filter = new MetricsFilter(configuration) {
-        override val metrics = List.empty[RequestMetric[_]]
+        override val metrics = List.empty[RequestMetric[_, RequestHeader, Result]]
       }
 
       filter.excludePaths must have size 1 // only check size since cannot compare Regex's

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
@@ -1,0 +1,57 @@
+package com.github.stijndehaes.playprometheusfilters.filters
+
+import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
+import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultUnmatchedDefaults, RequestMetric}
+import com.github.stijndehaes.playprometheusfilters.mocks.MockController
+import com.typesafe.config.ConfigFactory
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
+
+  val configuration = Configuration(ConfigFactory.parseString(
+    """play-prometheus-filters.exclude.paths = ["/test"]"""
+  ))
+
+  "Filter constructor" should {
+    "Get exclude paths from configuration" in {
+      implicit val mat = app.materializer
+      val filter = new MetricsFilter(configuration) {
+        override val metrics = List.empty[RequestMetric[_]]
+      }
+
+      filter.excludePaths must have size 1 // only check size since cannot compare Regex's
+    }
+  }
+
+  "Apply method" should {
+    "skip metrics for excluded paths" in {
+      implicit val mat = app.materializer
+      val collectorRegistry = mock[CollectorRegistry]
+      val filter = new MetricsFilter(configuration) {
+        override val metrics = List(
+          CounterRequestMetricBuilder.build(collectorRegistry, DefaultUnmatchedDefaults)
+        )
+      }
+
+      val rh = FakeRequest("GET", "/test")
+      val action = new MockController(stubControllerComponents()).ok
+
+      await(filter(action)(rh).run())
+
+      val metrics = filter.metrics(0).metric.collect()
+      metrics must have size 1
+      val samples = metrics.get(0).samples
+      samples.size() mustBe 0 // expect no metrics
+    }
+  }
+
+}

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -8,6 +8,7 @@ import org.mockito.Mockito.verify
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.routing.{HandlerDef, Router}
@@ -19,18 +20,19 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class RouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
   private implicit val mat = app.materializer
+  private val configuration = mock[Configuration]
 
   "Filter constructor" should {
     "Add a histogram to the prometheus registry" in {
       val collectorRegistry = mock[CollectorRegistry]
-      new RouteLatencyFilter(collectorRegistry)
+      new RouteLatencyFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
     }
   }
 
   "Apply method" should {
     "Measure the latency" in {
-      val filter = new RouteLatencyFilter(mock[CollectorRegistry])
+      val filter = new RouteLatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest().withAttrs( TypedMap(
         Router.Attrs.HandlerDef -> HandlerDef(null, null, null, "test", null, null ,null ,null ,null)
       ))
@@ -49,7 +51,7 @@ class RouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSuga
     }
 
     "Measure the latency for an unmatched route" in {
-      val filter = new RouteLatencyFilter(mock[CollectorRegistry])
+      val filter = new RouteLatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).error
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -1,6 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -64,7 +64,7 @@ class RouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSuga
       val countSample = samples.get(samples.size() - 2)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 1
-      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
+      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -1,5 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -37,7 +38,7 @@ class RouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSuga
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestLatency.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
@@ -54,14 +55,14 @@ class RouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSuga
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestLatency.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
       val countSample = samples.get(samples.size() - 2)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 1
-      countSample.labelValues.get(0) mustBe RouteLatencyFilter.unmatchedRoute
+      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -1,5 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -37,7 +38,7 @@ class StatusAndRouteCounterFilterSpec extends WordSpec with MustMatchers with Mo
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestCounter.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
@@ -58,18 +59,18 @@ class StatusAndRouteCounterFilterSpec extends WordSpec with MustMatchers with Mo
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestCounter.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
       val countSample = samples.get(0)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe StatusAndRouteCounterFilter.unmatchedRoute
+      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe StatusAndRouteCounterFilter.unmatchedController
-      countSample.labelValues.get(3) mustBe StatusAndRouteCounterFilter.unmatchedPath
-      countSample.labelValues.get(4) mustBe StatusAndRouteCounterFilter.unmatchedVerb
+      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -1,6 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -68,11 +68,11 @@ class StatusAndRouteCounterFilterSpec extends WordSpec with MustMatchers with Mo
       val countSample = samples.get(0)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
+      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
-      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
-      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
+      countSample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -8,6 +8,7 @@ import org.mockito.Mockito.verify
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results
 import play.api.routing.{HandlerDef, Router}
@@ -19,18 +20,19 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class StatusAndRouteCounterFilterSpec extends WordSpec with MustMatchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
   private implicit val mat = app.materializer
+  private val configuration = mock[Configuration]
 
   "Filter constructor" should {
     "Add a histogram to the prometheus registry" in {
       val collectorRegistry = mock[CollectorRegistry]
-      new StatusAndRouteLatencyFilter(collectorRegistry)
+      new StatusAndRouteLatencyFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
     }
   }
 
   "Apply method" should {
     "Measure the count" in {
-      val filter = new StatusAndRouteCounterFilter(mock[CollectorRegistry])
+      val filter = new StatusAndRouteCounterFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest().withAttrs( TypedMap(
         Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null ,null)
       ))
@@ -53,7 +55,7 @@ class StatusAndRouteCounterFilterSpec extends WordSpec with MustMatchers with Mo
     }
 
     "Measure the count for an unmatched route" in {
-      val filter = new StatusAndRouteCounterFilter(mock[CollectorRegistry])
+      val filter = new StatusAndRouteCounterFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).error
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -1,5 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -38,7 +39,7 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends WordSpec with MustMatche
 
       await(filter(action)(rh).run())
 
-      val latencyMetrics = filter.requestLatency.collect()
+      val latencyMetrics = filter.metrics(0).metric.collect()
       latencyMetrics must have size 1
       val latencySamples = latencyMetrics.get(0).samples
       val latencySample = latencySamples.get(latencySamples.size() - 2)
@@ -50,7 +51,7 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends WordSpec with MustMatche
       latencySample.labelValues.get(3) mustBe "/path"
       latencySample.labelValues.get(4) mustBe "GET"
 
-      val countMetrics = filter.requestCounter.collect()
+      val countMetrics = filter.metrics(1).metric.collect()
       countMetrics must have size 1
       val countSamples = countMetrics.get(0).samples
       val countSample = countSamples.get(0)
@@ -70,30 +71,30 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends WordSpec with MustMatche
 
       await(filter(action)(rh).run())
 
-      val latencyMetrics = filter.requestLatency.collect()
+      val latencyMetrics = filter.metrics(0).metric.collect()
       latencyMetrics must have size 1
       val latencySamples = latencyMetrics.get(0).samples
       val latencySample = latencySamples.get(latencySamples.size() - 2)
 
       latencySample.value mustBe 1.0
       latencySample.labelValues must have size 5
-      latencySample.labelValues.get(0) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedRoute
+      latencySample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
       latencySample.labelValues.get(1) mustBe "404"
-      latencySample.labelValues.get(2) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedController
-      latencySample.labelValues.get(3) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedPath
-      latencySample.labelValues.get(4) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedVerb
+      latencySample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
+      latencySample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
+      latencySample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
 
-      val countMetrics = filter.requestCounter.collect()
+      val countMetrics = filter.metrics(1).metric.collect()
       countMetrics must have size 1
       val countSamples = countMetrics.get(0).samples
       val countSample = countSamples.get(0)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedRoute
+      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedController
-      countSample.labelValues.get(3) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedPath
-      countSample.labelValues.get(4) mustBe StatusAndRouteLatencyAndCounterFilter.unmatchedVerb
+      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -1,6 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -80,11 +80,11 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends WordSpec with MustMatche
 
       latencySample.value mustBe 1.0
       latencySample.labelValues must have size 5
-      latencySample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
+      latencySample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
       latencySample.labelValues.get(1) mustBe "404"
-      latencySample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
-      latencySample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
-      latencySample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
+      latencySample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
+      latencySample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
+      latencySample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
 
       val countMetrics = filter.metrics(1).metric.collect()
       countMetrics must have size 1
@@ -92,12 +92,11 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends WordSpec with MustMatche
       val countSample = countSamples.get(0)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
+      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
-      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
-      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
+      countSample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
     }
   }
-
 }

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -1,5 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -37,7 +38,7 @@ class StatusAndRouteLatencyFilterSpec extends WordSpec with MustMatchers with Mo
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestLatency.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
@@ -58,18 +59,18 @@ class StatusAndRouteLatencyFilterSpec extends WordSpec with MustMatchers with Mo
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestLatency.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       //this is the count sample
       val countSample = samples.get(samples.size() - 2)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe StatusAndRouteLatencyFilter.unmatchedRoute
+      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe StatusAndRouteLatencyFilter.unmatchedController
-      countSample.labelValues.get(3) mustBe StatusAndRouteLatencyFilter.unmatchedPath
-      countSample.labelValues.get(4) mustBe StatusAndRouteLatencyFilter.unmatchedVerb
+      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
     }
   }
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -1,6 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
@@ -68,12 +68,11 @@ class StatusAndRouteLatencyFilterSpec extends WordSpec with MustMatchers with Mo
       val countSample = samples.get(samples.size() - 2)
       countSample.value mustBe 1.0
       countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe DefaultUnmatchedDefaults.UnmatchedRouteString
+      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
       countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe DefaultUnmatchedDefaults.UnmatchedControllerString
-      countSample.labelValues.get(3) mustBe DefaultUnmatchedDefaults.UnmatchedPathString
-      countSample.labelValues.get(4) mustBe DefaultUnmatchedDefaults.UnmatchedVerbString
+      countSample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
+      countSample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
+      countSample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
     }
   }
-
 }

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -8,6 +8,7 @@ import org.mockito.Mockito.verify
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results
 import play.api.routing.{HandlerDef, Router}
@@ -19,18 +20,19 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class StatusAndRouteLatencyFilterSpec extends WordSpec with MustMatchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
   private implicit val mat = app.materializer
+  private val configuration = mock[Configuration]
 
   "Filter constructor" should {
     "Add a histogram to the prometheus registry" in {
       val collectorRegistry = mock[CollectorRegistry]
-      new StatusAndRouteLatencyFilter(collectorRegistry)
+      new StatusAndRouteLatencyFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
     }
   }
 
   "Apply method" should {
     "Measure the latency" in {
-      val filter = new StatusAndRouteLatencyFilter(mock[CollectorRegistry])
+      val filter = new StatusAndRouteLatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest().withAttrs( TypedMap(
         Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null ,null)
       ))
@@ -53,7 +55,7 @@ class StatusAndRouteLatencyFilterSpec extends WordSpec with MustMatchers with Mo
     }
 
     "Measure the latency for an unmatched route" in {
-      val filter = new StatusAndRouteLatencyFilter(mock[CollectorRegistry])
+      val filter = new StatusAndRouteLatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).error
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito.verify
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.mvc.Results
 import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
@@ -16,18 +17,19 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class StatusCounterFilterSpec extends WordSpec with MustMatchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
   private implicit val mat = app.materializer
+  private val configuration = mock[Configuration]
 
   "Filter constructor" should {
     "Add a counter to the prometheus registry" in {
       val collectorRegistry = mock[CollectorRegistry]
-      new StatusCounterFilter(collectorRegistry)
+      new StatusCounterFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
     }
   }
 
   "Apply method" should {
     "Count the requests with status" in {
-      val filter = new StatusCounterFilter(mock[CollectorRegistry])
+      val filter = new StatusCounterFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).ok
 

--- a/test/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
+++ b/test/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
@@ -33,7 +33,7 @@ class StatusCounterFilterSpec extends WordSpec with MustMatchers with MockitoSug
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.requestCounter.collect()
+      val metrics = filter.metrics(0).metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       samples.get(0).value mustBe 1.0


### PR DESCRIPTION
Note: build on top of my other changes. See PR #16 .

Added two features:
- simpler customisation of metrics and possibility of changing defaults when metrics property is not found.
- possibility to exclude paths from metrics. E.g. to exclude /metrics endpoint.

Improves code by removing all duplicate code in Filter classes.