### PR TITLE
Add support for Scala 12.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 /.project
 /.settings
 /RUNNING_PID
+.bloop
+project/.bloop

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ target
 /.project
 /.settings
 /RUNNING_PID
-.bloop
-project/.bloop
+*/.bloop

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ https://github.com/stijndehaes/play-prometheus-filters-example-app
 To use the library add the following to you build.sbt:
 
 ```scala
-libraryDependencies += "com.github.stijndehaes" %% "play-prometheus-filters" % "0.5.0"
+libraryDependencies += "com.github.stijndehaes" %% "play-prometheus-filters" % "0.6.0"
 
 ```
-This latest version supports play 2.7.
+This latest version supports Play 2.8.
 For more info on play version compatibility see the releases matrix.
 
 
@@ -28,7 +28,7 @@ For more info on play version compatibility see the releases matrix.
 | 0.3.x       | 2.6.x        |
 | 0.4.x       | 2.6.x        |
 | 0.5.x       | 2.7.x        |
-
+| 0.6.x       | 2.8.x        |
 
 ## The filters
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,5 +55,5 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play"    %% "scalatestplus-play"         % "5.0.0"     % Test,
-  "org.mockito"               % "mockito-core"                % "2.16.0"    % Test
+  "org.mockito"               % "mockito-core"                % "3.2.4"    % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "play-prometheus-filters"
 organization := "com.github.stijndehaes"
 
-version := "0.5.0"
+version := "0.6.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -36,16 +36,17 @@ lazy val root = (project in file("."))
         </developer>
       </developers>
   )
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.1"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.11.12")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.8", "2.11.12")
 
-val playVersion = "2.7.1"
+val playVersion = "2.8.0"
+val prometheusClientVersion = "0.8.1"
 
 libraryDependencies ++= Seq(
-  "io.prometheus"             % "simpleclient"          % "0.6.0",
-  "io.prometheus"             % "simpleclient_hotspot"  % "0.6.0",
-  "io.prometheus"             % "simpleclient_servlet"  % "0.6.0",
+  "io.prometheus"             % "simpleclient"          % prometheusClientVersion,
+  "io.prometheus"             % "simpleclient_hotspot"  % prometheusClientVersion,
+  "io.prometheus"             % "simpleclient_servlet"  % prometheusClientVersion,
 
   // Play libs. Are provided not to enforce a specific version.
   "com.typesafe.play"         %% "play"                 % playVersion % Provided,
@@ -53,6 +54,6 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play"    %% "scalatestplus-play"         % "4.0.2"     % Test,
+  "org.scalatestplus.play"    %% "scalatestplus-play"         % "5.0.0"     % Test,
   "org.mockito"               % "mockito-core"                % "2.16.0"    % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.3.3

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/PrometheusModuleSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/PrometheusModuleSpec.scala
@@ -20,7 +20,7 @@ class PrometheusModuleSpec extends WordSpec with MustMatchers with BeforeAndAfte
         .build()
 
       val collector = app.injector.instanceOf[CollectorRegistry]
-      val collectors = PrivateMethod[java.util.HashSet[Collector]]('collectors)
+      val collectors = PrivateMethod[java.util.HashSet[Collector]](Symbol("collectors"))
       (collector invokePrivate collectors()).size must be > 0
     }
 
@@ -31,7 +31,7 @@ class PrometheusModuleSpec extends WordSpec with MustMatchers with BeforeAndAfte
         .build()
 
       val collector = app.injector.instanceOf[CollectorRegistry]
-      val collectors = PrivateMethod[java.util.HashSet[Collector]]('collectors)
+      val collectors = PrivateMethod[java.util.HashSet[Collector]](Symbol("collectors"))
       (collector invokePrivate collectors()).size must be (0)
     }
   }
@@ -43,7 +43,7 @@ class PrometheusModuleSpec extends WordSpec with MustMatchers with BeforeAndAfte
     /**
       * @return Registered exporter names.
       */
-    def getExporterNames: Seq[String] = {
+    def getExporterNames: collection.Seq[String] = {
       val exportNames = collection.mutable.Buffer.empty[String]
       val mfs = registry.metricFamilySamples()
       while(mfs.hasMoreElements) {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
@@ -5,7 +5,7 @@ import java.util.Collections
 import io.prometheus.client.Collector.MetricFamilySamples
 import io.prometheus.client.{Collector, CollectorRegistry}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.mvc.Results
 import play.api.test.FakeRequest

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
@@ -4,7 +4,7 @@ import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
@@ -5,7 +5,7 @@ import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultPlayUnmatche
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import com.typesafe.config.ConfigFactory
 import io.prometheus.client.CollectorRegistry
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -5,7 +5,7 @@ import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -5,7 +5,7 @@ import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -6,7 +6,7 @@ import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.times
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -5,7 +5,7 @@ import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
@@ -4,7 +4,7 @@ import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration


### PR DESCRIPTION
* Add support for Scala 2.13.1
* Bump project version to 0.6.0
* Add bloop folders to `.gitignore`
* Upgrade all the dependencies
* Use `MockitoSugar` from `scalatestplus` (one from `scalatest` is deprecated)